### PR TITLE
Changed README.m to correct bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ createdb noodle
 5. Add a user with the name `noodle`
 ```
 createuser noodle
-psql -d noodle -c "CREATE USER noodle WITH PASSWORD 'noodle'; GRANT ALL ON ALL TABLE IN SCHEMA public TO noodle;"
+psql -d noodle -c "CREATE USER noodle WITH PASSWORD 'noodle'; GRANT ALL ON ALL TABLES IN SCHEMA public TO noodle;"
 ```
 
 For more information see the the Section [Server Setup and Operation](https://www.postgresql.org/docs/14/runtime.html) in the PostgreSQL-Documentation or the [PostgreSQL-Entry](https://wiki.archlinux.org/title/PostgreSQL) in the Arch Linux-Wiki.


### PR DESCRIPTION
This pull request should fix the bug mentioned in issue #40:
 
> When setting up the installation, I found that the current  command
> ```
> psql -d noodle -c "CREATE USER noodle WITH PASSWORD 'noodle'; GRANT ALL ON ALL TABLE IN SCHEMA public TO noodle;"
> ```
> returns the error  
> ```
> FEHLER:  Syntaxfehler bei »TABLE«
> ZEILE 1: ...R noodle WITH PASSWORD 'noodle'; GRANT ALL ON ALL TABLE IN S...
> ```
> 
> To fix this, I just simply had to change the instruction "TABLE" to "TABLES"